### PR TITLE
CFE-3991: Added CompareVersionExpression() for comparing 2 version numbers

### DIFF
--- a/libutils/version_comparison.c
+++ b/libutils/version_comparison.c
@@ -1,6 +1,7 @@
+#include <assert.h>     // assert()
+#include <stdio.h>      // sscanf
+#include <string_lib.h> // StringEqual()
 #include <version_comparison.h>
-#include <stdio.h> // sscanf
-#include <assert.h> // assert()
 
 VersionComparison CompareVersion(const char *a, const char *b)
 {
@@ -75,4 +76,39 @@ VersionComparison CompareVersion(const char *a, const char *b)
     assert(a_patch == b_patch);
 
     return VERSION_EQUAL;
+}
+
+BooleanOrError CompareVersionExpression(
+    const char *const a, const char *const operator, const char * const b)
+{
+    const VersionComparison r = CompareVersion(a, b);
+    if (r == VERSION_ERROR)
+    {
+        return BOOLEAN_ERROR;
+    }
+    if (StringEqual(operator, "=") || StringEqual(operator, "=="))
+    {
+        return (BooleanOrError) (r == VERSION_EQUAL);
+    }
+    if (StringEqual(operator, ">"))
+    {
+        return (BooleanOrError) (r == VERSION_GREATER);
+    }
+    if (StringEqual(operator, "<"))
+    {
+        return (BooleanOrError) (r == VERSION_SMALLER);
+    }
+    if (StringEqual(operator, ">="))
+    {
+        return (BooleanOrError) (r == VERSION_GREATER || r == VERSION_EQUAL);
+    }
+    if (StringEqual(operator, "<="))
+    {
+        return (BooleanOrError) (r == VERSION_SMALLER || r == VERSION_EQUAL);
+    }
+    if (StringEqual(operator, "!="))
+    {
+        return (BooleanOrError) (r != VERSION_EQUAL);
+    }
+    return BOOLEAN_ERROR;
 }

--- a/libutils/version_comparison.h
+++ b/libutils/version_comparison.h
@@ -1,6 +1,8 @@
 #ifndef CF_VERSION_COMPARISON_H
 #define CF_VERSION_COMPARISON_H
 
+#include <stdbool.h> // bool
+
 typedef enum VersionComparison
 {
     VERSION_SMALLER,
@@ -9,6 +11,27 @@ typedef enum VersionComparison
     VERSION_ERROR,
 } VersionComparison;
 
+typedef enum BooleanOrError
+{
+    BOOLEAN_ERROR = -1,
+    BOOLEAN_FALSE = false,
+    BOOLEAN_TRUE = true,
+} BooleanOrError;
+
 VersionComparison CompareVersion(const char *a, const char *b);
+
+/**
+  @brief Compare 2 version numbers using an operator.
+  @note This function is just a wrapper around CompareVersion().
+  @see CompareVersion()
+  @param [in] a The first version number of the expression.
+  @param [in] operator One of: [">", "<", "=", "==", "!=", ">=", "<="].
+  @param [in] b The second version number of the expression.
+  @return true or false or -1 (invalid operator or version numbers).
+*/
+BooleanOrError CompareVersionExpression(
+    const char *a,
+    const char *operator,
+    const char *b);
 
 #endif

--- a/tests/unit/version_comparison_test.c
+++ b/tests/unit/version_comparison_test.c
@@ -50,12 +50,33 @@ static void test_CompareVersion(void)
     assert_true(VERSION_ERROR == CompareVersion("", "3.16.0"));
 }
 
+static void test_CompareVersionExpression(void)
+{
+    assert_true(BOOLEAN_TRUE == CompareVersionExpression("1.2.3", "=", "1.2.3"));
+    assert_true(BOOLEAN_TRUE == CompareVersionExpression("1.2.3", "==", "1.2.3"));
+    assert_true(BOOLEAN_TRUE == CompareVersionExpression("1.2.3", "!=", "1.2.4"));
+    assert_true(BOOLEAN_TRUE == CompareVersionExpression("100.0.0", ">", "99.0.0"));
+    assert_true(BOOLEAN_TRUE == CompareVersionExpression("100.0.0", ">=", "99.0.0"));
+    assert_true(BOOLEAN_TRUE == CompareVersionExpression("99.88.77", "<", "999.0.0"));
+
+    assert_true(BOOLEAN_FALSE == CompareVersionExpression("1.2.3", "!=", "1.2.3"));
+    assert_true(BOOLEAN_FALSE == CompareVersionExpression("1.2.3", "=", "1.2.4"));
+    assert_true(BOOLEAN_FALSE == CompareVersionExpression("1.2.3", "==", "1.2.4"));
+    assert_true(BOOLEAN_FALSE == CompareVersionExpression("100.0.0", "<=", "99.0.0"));
+    assert_true(BOOLEAN_FALSE == CompareVersionExpression("100.0.0", "<", "99.0.0"));
+    assert_true(BOOLEAN_FALSE == CompareVersionExpression("99.88.77", ">=", "999.0.0"));
+
+    assert_true(BOOLEAN_ERROR == CompareVersionExpression("", "", ""));
+    assert_true(BOOLEAN_ERROR == CompareVersionExpression("1", "2", "3"));
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
     const UnitTest tests[] =
     {
         unit_test(test_CompareVersion),
+        unit_test(test_CompareVersionExpression),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
Will be used in the upcoming CFEngine policy function; `version_compare()`.

This function takes 3 arguments, 2 version numbers and an
operator between them, thus resembling an expression to evaluate.
(Is this version bigger than this version, etc.)

Internally it uses the exact same logic as we use for comparing the
currently installed CFEngine version, for the cf_version_minimum
and similar functions and macros.
