### PR TITLE
Change MapSize() complexity to O(1) even if it's a hash map

### DIFF
--- a/libutils/map.c
+++ b/libutils/map.c
@@ -118,15 +118,7 @@ size_t MapSize(const Map *map)
     }
     else
     {
-        MapIterator i = MapIteratorInit((Map*)map);
-        size_t size = 0;
-
-        while (MapIteratorNext(&i))
-        {
-            size++;
-        }
-
-        return size;
+        return map->hashmap->load;
     }
 }
 


### PR DESCRIPTION
No need to iterate, a HashMap has the `load` field which contains the number of elements in the map.

Ticket: CFE-3043
Changelog: Complexity of MapSize() is now O(1) in all cases