### PR TITLE
Define type Regex and implement RegexDestroy()

### DIFF
--- a/libutils/json-pcre.h
+++ b/libutils/json-pcre.h
@@ -8,6 +8,6 @@
 #include <regex.h>
 
 JsonElement *StringCaptureData(
-    const pcre2_code *regex, const char *pattern, const char *data);
+    const Regex *regex, const char *pattern, const char *data);
 
 #endif

--- a/libutils/json.c
+++ b/libutils/json.c
@@ -2933,7 +2933,7 @@ bool JsonErrorVisitor(ARG_UNUSED JsonElement *element, ARG_UNUSED void *data)
 // takes either a pre-compiled pattern OR a regex (one of the two shouldn't be
 // NULL)
 JsonElement *StringCaptureData(
-    const pcre2_code *const regex, const char *const pattern, const char *const data)
+    const Regex *const regex, const char *const pattern, const char *const data)
 {
     assert(regex != NULL || pattern != NULL);
     assert(data != NULL);

--- a/libutils/regex.h.in
+++ b/libutils/regex.h.in
@@ -39,20 +39,28 @@
 
 #include <sequence.h>                                           /* Seq */
 
+/**
+ * @note: The definition of the type Regex may change in the future, so code
+ *        using this header should avoid using pcre2_code and use Regex instead
+ *        and use RegexDestroy() instead of pcre2_code_free().
+ */
+typedef pcre2_code Regex;
+
 #define CFENGINE_REGEX_WHITESPACE_IN_CONTEXTS ".*[_A-Za-z0-9][ \\t]+[_A-Za-z0-9].*"
 
 /* Try to use CompileRegex() and StringMatchWithPrecompiledRegex(). */
-pcre2_code *CompileRegex(const char *pattern);
+Regex *CompileRegex(const char *pattern);
+void RegexDestroy(Regex *regex);
 bool StringMatch(const char *pattern, const char *str, size_t *start, size_t *end);
-bool StringMatchWithPrecompiledRegex(const pcre2_code *regex, const char *str,
+bool StringMatchWithPrecompiledRegex(const Regex *regex, const char *str,
                                      size_t *start, size_t *end);
 bool StringMatchFull(const char *pattern, const char *str);
-bool StringMatchFullWithPrecompiledRegex(const pcre2_code *regex, const char *str);
+bool StringMatchFullWithPrecompiledRegex(const Regex *regex, const char *str);
 Seq *StringMatchCaptures(const char *pattern, const char *str, const bool return_names);
-Seq *StringMatchCapturesWithPrecompiledRegex(const pcre2_code *pattern, const char *str, const bool return_names);
+Seq *StringMatchCapturesWithPrecompiledRegex(const Regex *pattern, const char *str, const bool return_names);
 bool CompareStringOrRegex(const char *value, const char *compareTo, bool regex);
 
 /* Does not free rx! */
-bool RegexPartialMatch(const pcre2_code *regex, const char *teststring);
+bool RegexPartialMatch(const Regex *regex, const char *teststring);
 
 #endif  /* CFENGINE_REGEX_H */


### PR DESCRIPTION
When migrating from PCRE to PCRE2 we had to make a change breaking API because all the functions working with REs were using the PCRE's type `pcre`. To avoid this change in the future, we define our own type `Regex` which we can later redefine without causing any API breakage.

This also requires a definition of `RegexDestroy()` for use instead of `pcre2_code_free()`.

Ticket: ENT-10629
Changelog: API working with regular expressions uses a custom
           type Regex instead of pcre2_code directly