### PR TITLE
ENT-10250, ENT-10490: Fixed glob compatibility function for Win32

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1533,7 +1533,7 @@ StringSet* GlobFileList(const char *pattern)
 {
     StringSet *set = StringSetNew();
     glob_t globbuf;
-    int globflags = 0; // TODO: maybe add GLOB_BRACE later
+    int globflags = GLOB_BRACE;
 
     const char* r_candidates[] = { "*", "*/*", "*/*/*", "*/*/*/*", "*/*/*/*/*", "*/*/*/*/*/*" };
     bool starstar = ( strstr(pattern, "**") != NULL );

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1546,14 +1546,6 @@ StringSet* GlobFileList(const char *pattern)
             SearchAndReplace(pattern, "**", candidates[pi]) :
             xstrdup(pattern);
 
-#ifdef _WIN32
-        if (strchr(expanded, '\\'))
-        {
-            Log(LOG_LEVEL_VERBOSE, "Found backslash escape character in glob pattern '%s'. "
-                "Was forward slash intended?", expanded);
-        }
-#endif
-
         if (glob(expanded, globflags, NULL, &globbuf) == 0)
         {
             for (size_t i = 0; i < globbuf.gl_pathc; i++)

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -272,6 +272,8 @@ int fsync(int fd);
 #define GLOB_NOSPACE 1
 #define GLOB_ABORTED 2
 #define GLOB_NOMATCH 3
+#define GLOB_APPEND (1 << 5) // Append results to previous call
+#define GLOB_BRACE (1 << 9)  // Expand brace expressions (GNU EXTENSION)
 typedef struct {
     size_t   gl_pathc;    /* Count of paths matched so far  */
     char   **gl_pathv;    /* List of matched pathnames.  */


### PR DESCRIPTION
- Added new glob compatibility function for Win32
- Added GLOB_BRACE to GlobFileList
- Removed log message about use of backslash in GlobFileList

Merge together:
* https://github.com/cfengine/enterprise/pull/784
* https://github.com/cfengine/core/pull/5413