### PR TITLE
Fixed `error: unknown type name ‘ssize_t’` on Solaris

### DIFF
--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -29,6 +29,7 @@
 #include <string.h>  // strstr()
 #include <stdarg.h> // va_list
 #include <compiler.h>
+#include <sys/types.h> // ssize_t
 
 
 typedef struct


### PR DESCRIPTION
After removing sequence.h include dependency from string_lib.h, it appears that there is no definition of `ssize_t` on SPARC 64 Solaris 11. Including sys/types.h should fix this issue.
