### PR TITLE
ENT-11434: Testing, don't merge!

### DIFF
--- a/tests/unit/glob_lib_test.c
+++ b/tests/unit/glob_lib_test.c
@@ -774,7 +774,8 @@ int main()
         unit_test(test_glob_match),
         unit_test(test_glob_find),
 #endif // WITH_PCRE2
-        unit_test(test_glob_file_list),
+        // Try once in jenkins without this test to see if acceptance tests pass
+        // unit_test(test_glob_file_list),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
Try once without the `test_glob_file_list` test in Jenkins to see if the
acceptance tests still pass. That would mean that there is something
wrong with the unit test, and not the implementation of globs.

Ticket: ENT-11434
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
