### PR TITLE
Use fancy and more efficient syscalls to copy (sparse) files on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -880,6 +880,24 @@ AC_CHECK_HEADERS(utmp.h)
 dnl POSIX way to get uptime
 AC_CHECK_HEADERS(utmpx.h)
 
+dnl ######################################################################
+dnl Fancy new Linux syscalls for file/data copying
+dnl ######################################################################
+AC_CHECK_HEADERS([linux/fs.h])
+AC_CHECK_DECLS([FICLONE], [], [], [#include <linux/fs.h>])
+AC_CHECK_DECLS([SEEK_DATA], [], [], [
+#define _GNU_SOURCE
+#include <unistd.h>
+])
+AC_CHECK_DECLS([FALLOC_FL_PUNCH_HOLE], [], [], [
+#define _GNU_SOURCE
+#include <fcntl.h>
+])
+AC_CHECK_HEADERS([sys/sendfile.h])
+AC_CHECK_FUNCS([sendfile])
+AC_CHECK_FUNCS([copy_file_range])
+
+
 dnl #######################################################################
 dnl Newer BSD systems don't have a compatible rtentry - use ortentry
 dnl #######################################################################


### PR DESCRIPTION
The FICLONE ioctl() is the most efficient way to copy a file inside one file system if available and supported. copy_file_range() is an alternative that can provide similar efficiency, but also only works inside one file system and requires us to take care of holes in files. sendfile() is very similar, but unline copy_file_range() it doesn't support reflinks.

Ticket: CFE-4380
Changelog: FileSparseCopy() now uses FICLONE ioctl(),
           copy_file_range() or sendfile() on Linux
           platforms (if available)