### PR TITLE
CFE-4385: Temporary fix for GH Action failures

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -18,7 +18,11 @@ jobs:
     - name: Check tools versions
       run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
+      run: >
+        LDFLAGS="-L`brew --prefix lmdb`/lib -L`brew --prefix openssl`/lib -L`brew --prefix pcre2`/lib"
+        CPPFLAGS="-I`brew --prefix lmdb`/include -I`brew --prefix openssl`/include -I`brew --prefix pcre2`/include"
+        PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+        ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -12,9 +12,13 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl pcre2
+      run: brew install lmdb automake openssl pcre2 autoconf libtool
+    - name: Check tools
+      run: command -v libtool && command -v automake && command -v autoconf
+    - name: Check tools versions
+      run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug
+      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests


### PR DESCRIPTION
- **Fixed installation and PATH for libtool autoconf**
- **Use brew --prefix to locate LMDB, OpenSSL, and pcre**

Ported from https://github.com/cfengine/core/pull/5486
