### PR TITLE
libutils/writer: Removed spurious trailing whitespace

### DIFF
--- a/libutils/writer.c
+++ b/libutils/writer.c
@@ -351,6 +351,6 @@ void WriterWriteHelp(Writer *w, const Component *component,
         WriterWriteF(w, "\nWebsite: %s\n", component->website);
     }
     if (component->copyright != NULL) {
-        WriterWriteF(w, "This software is Copyright %s.\n ", component->copyright);
+        WriterWriteF(w, "This software is Copyright %s.\n", component->copyright);
     }
 }


### PR DESCRIPTION
Remove trailing whitespace after copyright in WriterWriteHelp().