### PR TITLE
Initialize OpenSSL before using it in hash_test

### DIFF
--- a/tests/unit/hash_test.c
+++ b/tests/unit/hash_test.c
@@ -40,6 +40,10 @@ void tests_setup()
         initialized = 0;
         return;
     }
+
+    OPENSSL_init_crypto(0, NULL);
+    initialized = 1;
+
     rsa = RSA_new();
     if (rsa)
     {
@@ -57,8 +61,6 @@ void tests_setup()
         RSA_generate_key_ex(rsa, 1024, bn, NULL);
         BN_free(bn);
     }
-    OpenSSL_add_all_digests();
-    initialized = 1;
 }
 
 void tests_teardown()


### PR DESCRIPTION
Also, use the new API for initializing OpenSSL instead of the deprecated one.