### PR TITLE
Fixed compiler warning for undefined reference of lstat

### DIFF
--- a/libutils/file_lib.h
+++ b/libutils/file_lib.h
@@ -26,6 +26,7 @@
 
 #include <stdbool.h> // bool
 #include <sys/types.h> // uid_t
+#include <sys/stat.h> // lstat
 #include <writer.h>
 #include <set.h>
 #include <sequence.h>


### PR DESCRIPTION
Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
