### PR TITLE
CFE-4401: Added MaskTerminationSignalsInThread() for re-use in CFEngine core for Termux platform

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -69,6 +69,7 @@ libutils_la_SOURCES = \
 	sequence.c sequence.h \
 	string_sequence.c string_sequence.h \
 	set.c set.h \
+	signal_lib.h \
 	stack.c stack.h \
 	threaded_stack.c threaded_stack.h \
 	statistics.c statistics.h \

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1945,7 +1945,7 @@ static int LockFD(int fd, short int lock_type, bool wait)
         {
             if (errno != EINTR)
             {
-                Log(LOG_LEVEL_DEBUG, "Failed to acquire file lock for FD %d: %s",
+                Log(LOG_LEVEL_DEBUG, "Failed to acquire file lock wait for FD %d: %s",
                     fd, GetErrorStr());
                 return -1;
             }

--- a/libutils/signal_lib.h
+++ b/libutils/signal_lib.h
@@ -1,0 +1,15 @@
+static inline void MaskTerminationSignalsInThread()
+{
+    /* Mask termination signals in a thread so that they always end up in the
+     * main thread. The function calls below should just always succeed and even
+     * if they didn't, there's nothing to do. */
+    sigset_t th_sigset;
+    NDEBUG_UNUSED int ret = sigemptyset(&th_sigset);
+    assert(ret == 0);
+    ret = sigaddset(&th_sigset, SIGINT);
+    assert(ret == 0);
+    ret = sigaddset(&th_sigset, SIGTERM);
+    assert(ret == 0);
+    ret = pthread_sigmask(SIG_BLOCK, &th_sigset, NULL);
+    assert(ret == 0);
+}


### PR DESCRIPTION
- Add MaskTerminationSignalsInThread() from cf-reactor for sharing
- On Android Termux fcntl file locks maybe arent supported at all. Make the debug message more specific about which file lock, wait or not, is failing.
