### PR TITLE
Sparse file copying no longer aborts if fallocate is unsupported

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1710,9 +1710,12 @@ bool FileSparseCopy(int sd, const char *src_name,
      */
     if (fallocate(dd, FALLOC_FL_KEEP_SIZE|FALLOC_FL_PUNCH_HOLE, 0, in_sb.st_blocks * 512) != 0)
     {
-        Log(LOG_LEVEL_ERR, "Failed to pre-allocate space for '%s': %m", dst_name);
-        *total_bytes_written = 0;
-        return false;
+        Log((errno == EOPNOTSUPP) ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
+            "Failed to pre-allocate space for '%s': %m", dst_name);
+        if (errno != EOPNOTSUPP) {
+            *total_bytes_written = 0;
+            return false;
+        }
     }
 
     off_t in_pos = 0;


### PR DESCRIPTION
On my Ubuntu 24 VM, I experienced that FileSparseCopy() kept getting
aborted with the following error message:

```
   error: Failed to pre-allocate space for 'promises.cf.cfnew': Operation not supported
```

In the man pages I saw that the system call fallocate(2) can fail if the
file system does not support it. However, fallocate(2) is nothing more
than an optimization. It is not strictly needed. Hence, the file copying
should proceed if fallocate(2) is unsupported.

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11639)](https://ci.cfengine.com/job/pr-pipeline/11639/)
