### PR TITLE
Bump deprecated versions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/asan_unit_tests.yml
+++ b/.github/workflows/asan_unit_tests.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   asan_unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install dependencies

--- a/.github/workflows/cmake_examples.yml
+++ b/.github/workflows/cmake_examples.yml
@@ -8,7 +8,7 @@ jobs:
   cmake_examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -35,7 +35,7 @@ jobs:
 
       - name: Autobuild (Python)
         if: ${{ matrix.language == 'python' }}
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
         
       - name: Install dependencies (C)
         if: ${{ matrix.language == 'cpp' }}
@@ -46,6 +46,6 @@ jobs:
         run: ./autogen.sh && make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
   macos_unit_tests:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install dependencies

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   nodeps_unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install dependencies
@@ -21,9 +21,9 @@ jobs:
       run: make check
 
   unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install dependencies


### PR DESCRIPTION
Ubuntu 20.04 runner is being deprecated.

> CodeQL Action major versions v1 and v2 have been deprecated. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

Changelog: None
Ticket: None