### PR TITLE
Moved GetRelocatedProcdirRoot() from libntech to core

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1935,21 +1935,6 @@ ssize_t CfReadLines(char **buff, size_t *size, FILE *fp, Seq *lines)
 
 /*******************************************************************/
 
-const char* GetRelocatedProcdirRoot()
-{
-    const char *procdir = getenv("CFENGINE_TEST_OVERRIDE_PROCDIR");
-    if (procdir == NULL)
-    {
-        procdir = "";
-    }
-    else
-    {
-        Log(LOG_LEVEL_VERBOSE, "Overriding /proc location to be %s", procdir);
-    }
-
-    return procdir;
-}
-
 
 #if !defined(__MINGW32__)
 

--- a/libutils/file_lib.h
+++ b/libutils/file_lib.h
@@ -210,12 +210,6 @@ ssize_t CfReadLine(char **buff, size_t *size, FILE *fp);
  */
 ssize_t CfReadLines(char **buff, size_t *size, FILE *fp, Seq *lines);
 
-/**
- * @brief For testing things against /proc, uses env var CFENGINE_TEST_OVERRIDE_PROCDIR
- * @return the extra directory to add BEFORE /proc in the path
- */
-const char* GetRelocatedProcdirRoot();
-
 /*********** File locking ***********/
 
 typedef struct _FileLock {

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -374,7 +374,7 @@ char *StringConcatenate(size_t count, const char *first, ...)
     char *result = xcalloc(total_length + 1, sizeof(char));
     if (first)
     {
-        strcat(result, first);
+        strncpy(result, first, total_length);
     }
 
     va_start(args, first);


### PR DESCRIPTION
Commit in core where this was moved is cfengine/core@3d914b512a9e92e0a06068934199f026c3761cd0

Ticket: CFE-3429