### PR TITLE
Fixed static-check to run autogen NO_CONFIGURE if needed and then configure in each test

### DIFF
--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -5,21 +5,30 @@ set -x
 n_procs="$(getconf _NPROCESSORS_ONLN)"
 
 function check_with_gcc() {
+  # previous runs may have cached configuration based on a different CC
+  rm -f config.cache
   make clean
-  ./autogen.sh --enable-debug CC=gcc
+  # here --config-cache enables lots of checks in subdir libntech to re-use checks made in core
+  ./configure --config-cache --enable-debug CC=gcc
   local gcc_exceptions="-Wno-sign-compare -Wno-enum-int-mismatch"
   make -j -l${n_procs} --keep-going CFLAGS="-Werror -Wall -Wextra $gcc_exceptions"
 }
 
 function check_with_clang() {
+  # previous runs may have cached configuration based on a different CC
+  rm -f config.cache
   make clean
-  ./autogen.sh --enable-debug CC=clang
+  # here --config-cache enables lots of checks in subdir libntech to re-use checks made in core
+  ./configure --config-cache --enable-debug CC=clang
   make -j -l${n_procs} --keep-going CFLAGS="-Werror -Wall -Wextra -Wno-sign-compare"
 }
 
 function check_with_cppcheck() {
+  # previous runs may have cached configuration based on a different CC
+  rm -f config.cache
   make clean
-  ./autogen.sh --enable-debug
+  # here --config-cache enables lots of checks in subdir libntech to re-use checks made in core
+  ./configure --config-cache --enable-debug
 
   # print out cppcheck version for comparisons over time in case of regressions due to newer versions
   cppcheck --version
@@ -43,6 +52,13 @@ cd "$(dirname $0)"/../../
 
 failure=0
 failures=""
+
+# in jenkins the workdir is already autogen'd
+# in github it is not, so do that work here
+if [ ! -f configure ]; then
+  NO_CONFIGURE=1 ./autogen.sh --enable-debug
+fi
+
 check_with_gcc              || { failures="${failures}FAIL: GCC check failed\n"; failure=1; }
 check_with_clang            || { failures="${failures}FAIL: Clang check failed\n"; failure=1; }
 check_with_cppcheck         || { failures="${failures}FAIL: cppcheck failed\n"; failure=1; }


### PR DESCRIPTION
Running autogen.sh in each test is inefficient.

We don't run this test direclty on libntech in jenkins but I included those comments to keep the files more in sync between core and libntech.
