### PR TITLE
CFE-4385: Fix build on macOS

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -19,9 +19,6 @@ jobs:
       run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
       run: >
-        LDFLAGS="-L`brew --prefix lmdb`/lib -L`brew --prefix openssl`/lib -L`brew --prefix pcre2`/lib"
-        CPPFLAGS="-I`brew --prefix lmdb`/include -I`brew --prefix openssl`/include -I`brew --prefix pcre2`/include"
-        PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
         ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,7 +66,7 @@ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 config.guess config.sub \
 ACLOCAL_AMFLAGS = -I m4
 
 list:
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | $EGREP -v -e '^[^[:alnum:]]' -e '^$@$$'
 
 install-data-local:
 	$(MKDIR_P) -m 700 $(DESTDIR)$(workdir)/inputs

--- a/configure.ac
+++ b/configure.ac
@@ -88,9 +88,22 @@ dnl ######################################################################
 dnl Checks for programs.
 dnl ######################################################################
 
+AC_PROG_GREP
+AC_PROG_EGREP
 AC_PROG_CC
 AC_PROG_MKDIR_P
 AC_EXEEXT
+
+AS_CASE([${target_os}],
+[darwin*], [
+    AC_CHECK_PROG([BREW], [brew], [brew])
+    AC_MSG_CHECKING([for OS X Homebrew])
+    AS_IF([test "x$BREW" = "xbrew"], [
+            have_brew=yes
+            AC_MSG_RESULT([OS X Homebrew detected])
+        ],
+        [have_brew=])
+])
 
 dnl GCC specific flags
 m4_include([m4/cf3_gcc_flags.m4])
@@ -245,13 +258,7 @@ AC_ARG_WITH(openssl,
     [AS_HELP_STRING([--with-openssl[[=PATH]]],
     [Specify OpenSSL path])], [], [with_openssl=yes])
 
-if  test -d /usr/local/Cellar/ && \
-    test -d /usr/local/opt/openssl/ && \
-    test "x$with_openssl" = "xyes" ; then
-    with_openssl=$(brew --prefix openssl)
-    echo "OS X Homebrew detected"
-    echo "Defaulting to: --with-openssl=$with_openssl"
-fi
+AS_IF([test "x$have_brew" = "xyes" && test -d $(brew --prefix openssl)/], [with_openssl=$(brew --prefix openssl)])
 
 if test "x$with_openssl" != "xno"; then
   CF3_WITH_LIBRARY(openssl, [
@@ -301,6 +308,8 @@ fi
 AC_ARG_WITH([pcre2], [AS_HELP_STRING([--with-pcre2[[=PATH]]], [Specify PCRE2 path])], [], [with_pcre2=yes])
 
 if test "x$with_pcre" != "xno" && test "x$with_pcre2" != "xno"; then
+  AS_IF([test "x$have_brew" = "xyes" && test -d $(brew --prefix pcre2)/], [with_pcre2=$(brew --prefix pcre2)])
+
   CF3_WITH_LIBRARY(pcre2, [
     AC_CHECK_LIB(pcre2-8, pcre2_compile_8, [], [AC_MSG_ERROR(Cannot find PCRE2)])
     AC_CHECK_HEADERS(
@@ -338,6 +347,8 @@ AC_ARG_WITH([libyaml],
 
 if test "x$with_libyaml" != xno
 then
+  AS_IF([test "x$have_brew" = "xyes" && test -d $(brew --prefix libyaml)/], [with_libyaml=$(brew --prefix libyaml)])
+
   CF3_WITH_LIBRARY(libyaml, [
     AC_CHECK_LIB(yaml, yaml_parser_initialize,
       [],

--- a/m4/cf3_platforms.m4
+++ b/m4/cf3_platforms.m4
@@ -28,13 +28,13 @@
 # Good example: use LINUX to select code which uses inotify and netlink sockets.
 # Bad example: use LINUX to select code which parses output of coreutils' ps(1).
 #
-AM_CONDITIONAL([LINUX], [test -n "`echo ${target_os} | grep linux`"])
-AM_CONDITIONAL([MACOSX], [test -n "`echo ${target_os} | grep darwin`"])
-AM_CONDITIONAL([SOLARIS], [test -n "`(echo ${target_os} | egrep 'solaris|sunos')`"])
-AM_CONDITIONAL([NT], [test -n "`(echo ${target_os} | egrep 'mingw|cygwin')`"])
-AM_CONDITIONAL([CYGWIN], [test -n "`(echo ${target_os} | egrep 'cygwin')`"])
-AM_CONDITIONAL([AIX], [test -n "`(echo ${target_os} | grep aix)`"])
-AM_CONDITIONAL([HPUX], [test -n "`(echo ${target_os} | egrep 'hpux|hp-ux')`"])
-AM_CONDITIONAL([FREEBSD], [test -n "`(echo ${target_os} | grep freebsd)`"])
-AM_CONDITIONAL([NETBSD], [test -n "`(echo ${target_os} | grep netbsd)`"])
-AM_CONDITIONAL([XNU], [test -n "`(echo ${target_os} | grep darwin)`"])
+AM_CONDITIONAL([LINUX], [echo ${target_os} | grep -q linux])
+AM_CONDITIONAL([MACOSX], [echo ${target_os} | grep -q darwin])
+AM_CONDITIONAL([SOLARIS], [echo ${target_os} | $EGREP -q 'solaris|sunos'])
+AM_CONDITIONAL([NT], [echo ${target_os} | $EGREP -q 'mingw|cygwin'])
+AM_CONDITIONAL([CYGWIN], [echo ${target_os} | grep -q 'cygwin'])
+AM_CONDITIONAL([AIX], [echo ${target_os} | grep -q aix])
+AM_CONDITIONAL([HPUX], [echo ${target_os} | $EGREP -q 'hpux|hp-ux'])
+AM_CONDITIONAL([FREEBSD], [echo ${target_os} | grep -q freebsd])
+AM_CONDITIONAL([NETBSD], [echo ${target_os} | grep -q netbsd])
+AM_CONDITIONAL([XNU], [echo ${target_os} | grep -q darwin])


### PR DESCRIPTION
Check for Homebrew if we're on Darwin and use brew's --prefix. Also use autoconf's macro for egrep to get rid of obsolescent warnings.

Ticket: CFE-4385