### PR TITLE
fsattrs.h: Added missing include for assert

### DIFF
--- a/libutils/fsattrs.h
+++ b/libutils/fsattrs.h
@@ -26,6 +26,7 @@
 #define CFENGINE_FSATTR_H
 
 #include <stdbool.h>
+#include <assert.h>
 
 typedef enum
 {


### PR DESCRIPTION
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
