### PR TITLE
ENT-13766: Fix inet_ntop/inet_pton declaration check for MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -807,7 +807,16 @@ AC_CHECK_DECLS(getaddrinfo, [], [AC_LIBOBJ(getaddrinfo)], [[
 #endif
 ]])
 
-AC_CHECK_DECLS([[inet_ntop], [inet_pton]], [], [], [[#include <arpa/inet.h>]])
+AC_CHECK_DECLS([[inet_ntop], [inet_pton]], [], [], [[
+#if HAVE_WINSOCK2_H
+    #include <winsock2.h>
+#endif
+#if HAVE_WS2TCPIP_H
+    #include <ws2tcpip.h>
+#else
+    #include <arpa/inet.h>
+#endif
+]])
 AC_REPLACE_FUNCS(inet_ntop inet_pton)
 
 AC_CHECK_FUNCS(getifaddrs)


### PR DESCRIPTION
## Summary
- The `AC_CHECK_DECLS` for `inet_ntop` and `inet_pton` only checked `<arpa/inet.h>`, which does not exist on MinGW. On MinGW these functions are declared in `<ws2tcpip.h>`.
- This caused `HAVE_DECL_INET_NTOP=0`, making `platform.h` re-declare `inet_ntop` with `socklen_t`. With mingw-w64 >= v11 (Ubuntu 24.04), `ws2tcpip.h` declares it with `size_t`, causing a conflicting types compilation error.
- Include the correct Winsock headers in the check, matching the pattern already used by the `getaddrinfo` check above.

Ticket: ENT-13766

🤖 Generated with [Claude Code](https://claude.com/claude-code)