### PR TITLE
Revert: CFE-4623: Fixed missing directory file separator suffix

### DIFF
--- a/libutils/glob_lib.c
+++ b/libutils/glob_lib.c
@@ -432,7 +432,7 @@ static void PathWalkCallback(
     {
         /* We have matched each and every part of the glob pattern, thus we
          * have a full match. */
-        char *const match = StringFormat("%s" FILE_SEPARATOR_STR, dirpath);
+        char *const match = xstrdup(dirpath);
         SeqAppend(data->matches, match);
         Log(LOG_LEVEL_DEBUG,
             "Full match! Directory '%s' has matched all previous sub patterns",
@@ -675,18 +675,11 @@ StringSet *GlobFileList(const char *pattern)
         free(expanded);
         expanded = tmp;
 
-        struct stat sb;
         if (glob(expanded, 0, NULL, &globbuf) == 0)
         {
             for (size_t j = 0; j < globbuf.gl_pathc; j++)
             {
-                if (stat(globbuf.gl_pathv[j], &sb) != 1)
-                {
-                    char *path = S_ISDIR(sb.st_mode)
-                        ? StringFormat("%s" FILE_SEPARATOR_STR, globbuf.gl_pathv[j])
-                        : SafeStringDuplicate(globbuf.gl_pathv[j]);
-                    StringSetAdd(set, path);
-                }
+                StringSetAdd(set, SafeStringDuplicate(globbuf.gl_pathv[j]));
             }
             globfree(&globbuf);
         }

--- a/tests/unit/glob_lib_test.c
+++ b/tests/unit/glob_lib_test.c
@@ -271,7 +271,7 @@ static void test_glob_find(void)
     {
         Seq *const matches = GlobFind(".");
         assert_int_equal(SeqLength(matches), 1);
-        assert_string_equal(SeqAt(matches, 0), "." FILE_SEPARATOR_STR);
+        assert_string_equal(SeqAt(matches, 0), ".");
         SeqDestroy(matches);
     }
 }
@@ -289,10 +289,10 @@ static void test_glob_file_list(void)
     // Create test subdirectories.
 
     static const char *const test_subdirs[] = {
-        "foo" FILE_SEPARATOR_STR,
-        "foo" FILE_SEPARATOR_STR "bar" FILE_SEPARATOR_STR,
-        "foo" FILE_SEPARATOR_STR "bar" FILE_SEPARATOR_STR "baz" FILE_SEPARATOR_STR,
-        "qux" FILE_SEPARATOR_STR,
+        "foo",
+        "foo" FILE_SEPARATOR_STR "bar",
+        "foo" FILE_SEPARATOR_STR "bar" FILE_SEPARATOR_STR "baz",
+        "qux",
     };
     const size_t num_test_subdirs =
         sizeof(test_subdirs) / sizeof(const char *);
@@ -471,14 +471,14 @@ static void test_glob_file_list(void)
     matches = GlobFileList(pattern);
     assert_int_equal(StringSetSize(matches), 4);
 
-    ret = snprintf(path, PATH_MAX, "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR, test_dir);
+    ret = snprintf(path, PATH_MAX, "%s" FILE_SEPARATOR_STR "foo", test_dir);
     assert_true(ret < PATH_MAX && ret >= 0);
     assert_true(StringSetContains(matches, path));
 
     ret = snprintf(
         path,
         PATH_MAX,
-        "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR "bar" FILE_SEPARATOR_STR,
+        "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR "bar",
         test_dir);
     assert_true(ret < PATH_MAX && ret >= 0);
     assert_true(StringSetContains(matches, path));
@@ -487,12 +487,12 @@ static void test_glob_file_list(void)
         path,
         PATH_MAX,
         "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR
-        "bar" FILE_SEPARATOR_STR "baz" FILE_SEPARATOR_STR,
+        "bar" FILE_SEPARATOR_STR "baz",
         test_dir);
     assert_true(ret < PATH_MAX && ret >= 0);
     assert_true(StringSetContains(matches, path));
 
-    ret = snprintf(path, PATH_MAX, "%s" FILE_SEPARATOR_STR "qux" FILE_SEPARATOR_STR, test_dir);
+    ret = snprintf(path, PATH_MAX, "%s" FILE_SEPARATOR_STR "qux", test_dir);
     assert_true(ret < PATH_MAX && ret >= 0);
     assert_true(StringSetContains(matches, path));
 
@@ -676,14 +676,14 @@ static void test_glob_file_list(void)
 
     assert_int_equal(StringSetSize(matches), 2);
 
-    ret = snprintf(path, PATH_MAX, "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR, test_dir);
+    ret = snprintf(path, PATH_MAX, "%s" FILE_SEPARATOR_STR "foo", test_dir);
     assert_true(ret < PATH_MAX && ret >= 0);
     assert_true(StringSetContains(matches, path));
 
     ret = snprintf(
         path,
         PATH_MAX,
-        "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR "bar" FILE_SEPARATOR_STR,
+        "%s" FILE_SEPARATOR_STR "foo" FILE_SEPARATOR_STR "bar",
         test_dir);
     assert_true(ret < PATH_MAX && ret >= 0);
     assert_true(StringSetContains(matches, path));


### PR DESCRIPTION
Reverts https://github.com/NorthernTechHQ/libntech/pull/263

- **Revert "Fixed unit tests for directory separator suffix"**
- **Revert "Fixed missing directory file separator suffix"**

Caused valgrind checks to fail
```
  notice: Q: ".../cf-agent" -f /":    error: Maximum recursion level reached at '/var/cfengine/inputs/cfe_internal/update/../../modules/packages/vendored'
Q: ".../cf-agent" -f /":    error: Errors encountered when actuating files promise '/var/cfengine/modules/packages/vendored'
Q: ".../cf-agent" -f /":    error: Method 'modules_presence' failed in some repairs
Q: ".../cf-agent" -f /":    error: Method 'cfe_internal_update_policy_cpv' failed in some repairs
```

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline)](https://ci.cfengine.com/job/pr-pipeline/13495/)