### PR TITLE
ENT-13809: Fixed bug where files promise fails on vfat file systems

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1716,6 +1716,9 @@ bool FileSparseCopy(int sd, const char *src_name,
             *total_bytes_written = 0;
             return false;
         }
+        /* Clear errno so a later 'error = errno' in the copy loop doesn't
+         * capture this stale EOPNOTSUPP and cause a false failure report. */
+        errno = 0;
     }
 
     off_t in_pos = 0;


### PR DESCRIPTION
## Summary

When the destination filesystem does not support `fallocate()` (e.g. vfat), the call fails with `EOPNOTSUPP`. This was treated as non-fatal, but `errno` was left set. A subsequent successful `copy_file_range()` or `sendfile()` does not clear `errno`, so `error = errno` in the copy loop captured the stale `EOPNOTSUPP` and `FileSparseCopy` returned false even though the copy succeeded.

This caused files-promise edits on vfat to fail with:

```
error: Can't copy '/mnt/vfat-test/test.cfg' to '/mnt/vfat-test/test.cfg.cf-before-edit' - so promised edits could not be moved into place.
```

Fix: clear `errno` after gracefully handling the `EOPNOTSUPP` from `fallocate`.