### PR TITLE
Fix sparse copy

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1710,9 +1710,10 @@ bool FileSparseCopy(int sd, const char *src_name,
      */
     if (fallocate(dd, FALLOC_FL_KEEP_SIZE|FALLOC_FL_PUNCH_HOLE, 0, in_sb.st_blocks * 512) != 0)
     {
-        Log((errno == EOPNOTSUPP) ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
+        bool prealloc_not_supported = errno == EOPNOTSUPP;
+        Log(prealloc_not_supported ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
             "Failed to pre-allocate space for '%s': %m", dst_name);
-        if (errno != EOPNOTSUPP) {
+        if (!prealloc_not_supported) {
             *total_bytes_written = 0;
             return false;
         }


### PR DESCRIPTION
Save unsupported operation error so that correct error is used after Log()'ing.

Some filesystems (e.g. pmxcfs [1]) do not support fallocate(), so standard way for copying files (cf-before-edit/cf-after-edit) around will fail on these filesystems. This is fine as copying might still succeed. But to proceed we need to check returned error code, which might get overwritten by other function calls.

[1] https://pve.proxmox.com/wiki/Proxmox_Cluster_File_System_(pmxcfs)