### PR TITLE
CFE-4401: Fixes for building CFEngine core on Termux Android environment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -929,7 +929,7 @@ AC_CHECK_DECLS([FALLOC_FL_PUNCH_HOLE], [], [], [
 ])
 AC_CHECK_HEADERS([sys/sendfile.h])
 AC_CHECK_FUNCS([sendfile])
-AC_CHECK_FUNCS([copy_file_range])
+AC_CHECK_DECL([copy_file_range])
 
 
 dnl #######################################################################

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -70,6 +70,7 @@ libutils_la_SOURCES = \
 	sequence.c sequence.h \
 	string_sequence.c string_sequence.h \
 	set.c set.h \
+	signal_lib.h \
 	stack.c stack.h \
 	threaded_stack.c threaded_stack.h \
 	statistics.c statistics.h \

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1957,7 +1957,7 @@ static int LockFD(int fd, short int lock_type, bool wait)
         {
             if (errno != EINTR)
             {
-                Log(LOG_LEVEL_DEBUG, "Failed to acquire file lock for FD %d: %s",
+                Log(LOG_LEVEL_DEBUG, "Failed to acquire file lock wait for FD %d: %s",
                     fd, GetErrorStr());
                 return -1;
             }

--- a/libutils/signal_lib.h
+++ b/libutils/signal_lib.h
@@ -1,0 +1,15 @@
+static inline void MaskTerminationSignalsInThread()
+{
+    /* Mask termination signals in a thread so that they always end up in the
+     * main thread. The function calls below should just always succeed and even
+     * if they didn't, there's nothing to do. */
+    sigset_t th_sigset;
+    NDEBUG_UNUSED int ret = sigemptyset(&th_sigset);
+    assert(ret == 0);
+    ret = sigaddset(&th_sigset, SIGINT);
+    assert(ret == 0);
+    ret = sigaddset(&th_sigset, SIGTERM);
+    assert(ret == 0);
+    ret = pthread_sigmask(SIG_BLOCK, &th_sigset, NULL);
+    assert(ret == 0);
+}


### PR DESCRIPTION
- **Add MaskTerminationSignalsInThread() from cf-reactor for sharing**
- **On Android Termux fcntl file locks maybe arent supported at all. Make the debug message more specific about which file lock, wait or not, is failing.**
- **    Fixed check for copy_file_range on Android**
