### PR TITLE
ENT-14145: Fixed GlobFind walks unrelated parents of literal path components

### DIFF
--- a/libutils/glob_lib.c
+++ b/libutils/glob_lib.c
@@ -277,6 +277,28 @@ static char *TranslateGlob(const char *const pattern)
     return res;
 }
 
+bool IsWildcardPattern(const char *const str)
+{
+    assert(str != NULL);
+    /* A component is a wildcard pattern if it contains any glob metacharacter
+     * ('*', '?', '['/']') OR a brace-expansion character ('{', '}').
+     *
+     * Braces matter because GlobMatch() expands them (see ExpandBraces()): a
+     * directory component like "{lib,log}" must NOT be peeled as a literal
+     * prefix, or PeelLiteralPrefix() would stat(2) it verbatim and the whole
+     * pattern would silently match nothing (ENT-14146 review).
+     *
+     * Conservative by design -- it may report a pattern where none truly
+     * exists; this only forfeits the literal-prefix optimization, it never
+     * changes match results, because such a component then falls back to
+     * PathWalk() + GlobMatch():
+     *  - Backslash-escaped metacharacters (e.g. "\\*") still count as a
+     *    pattern here; the fallback path honors the escape.
+     *  - A lone ']' with no matching '[' is not really a wildcard, but is
+     *    reported as one anyway. */
+    return strpbrk(str, "*?[]{}") != NULL;
+}
+
 bool GlobMatch(const char *const _pattern, const char *const _filename)
 {
     assert(_pattern != NULL);
@@ -545,6 +567,84 @@ static bool EmptyStringFilter(void *item)
     return StringEqual(str, "");
 }
 
+/**
+ * Peel literal components off the head of @p components so that PathWalk()
+ * can begin at the deepest literal directory instead of the filesystem root
+ * (for absolute patterns) or the current directory (for relative patterns).
+ * Removed components are detached from the sequence and freed.
+ *
+ * @p seed is the directory prefix that the first peeled component is joined
+ * to -- "/" for absolute patterns, "" (or NULL) for relative patterns. The
+ * empty/NULL form deliberately avoids prepending "./", because PathWalk()
+ * formats matches differently when started at "." versus a named relative
+ * directory: starting at "." emits matches without a "./" prefix, while
+ * starting at "./foo" emits "./foo/match". Building the relative start_dir
+ * bare (e.g. "test_dir/sub") preserves the convention that matches for a
+ * relative pattern come back without a "./" prefix.
+ *
+ * Returns a newly-allocated directory path; the caller must free it.
+ * Returns NULL if the literal prefix does not exist or is not a directory,
+ * in which case the pattern has no matches and PathWalk() should be skipped
+ * entirely. If no components were peeled, the returned path is "/" (when
+ * seed is "/") or "." (when seed is "" or NULL). See ENT-14146.
+ *
+ * At least one component is always retained in @p components for the final
+ * match step performed by PathWalkCallback().
+ */
+static char *PeelLiteralPrefix(const char *const seed, Seq *const components)
+{
+    assert(components != NULL);
+
+    char *start_dir = NULL;
+    while (SeqLength(components) > 1)
+    {
+        char *const head = SeqAt(components, 0);
+        if (IsWildcardPattern(head))
+        {
+            break;
+        }
+        char *next;
+        if (start_dir == NULL)
+        {
+            /* First peel. For absolute patterns, prefix with the seed
+             * ("/" + "var" = "/var"). For relative patterns, take the
+             * component bare so the output path stays relative without a
+             * "./" prefix. */
+            next = (seed == NULL || seed[0] == '\0')
+                       ? SafeStringDuplicate(head)
+                       : Path_JoinAlloc(seed, head);
+        }
+        else
+        {
+            next = Path_JoinAlloc(start_dir, head);
+        }
+        free(start_dir);
+        start_dir = next;
+        /* SeqSoftRemove() detaches the element from the sequence without
+         * freeing it (mirroring how PathWalkCallback() pops components).
+         * Free the orphaned string ourselves. */
+        SeqSoftRemove(components, 0);
+        free(head);
+    }
+
+    if (start_dir == NULL)
+    {
+        /* Nothing peeled -- fall back to the seed (or "." for relative). */
+        return SafeStringDuplicate(
+            (seed != NULL && seed[0] != '\0') ? seed : ".");
+    }
+
+    /* Confirm the resolved prefix exists and is a directory. stat(2) follows
+     * symlinks, so a symlinked literal prefix still resolves. */
+    struct stat sb;
+    if (stat(start_dir, &sb) != 0 || !S_ISDIR(sb.st_mode))
+    {
+        free(start_dir);
+        return NULL;
+    }
+    return start_dir;
+}
+
 Seq *GlobFind(const char *pattern)
 {
     assert(pattern != NULL);
@@ -605,23 +705,54 @@ Seq *GlobFind(const char *pattern)
             }
             else
             {
-                // Path like '/...'.
+                /* Path like '/...'. */
+                char *const start_dir =
+                    PeelLiteralPrefix(FILE_SEPARATOR_STR, data.components);
+                if (start_dir == NULL)
+                {
+                    Log(LOG_LEVEL_DEBUG,
+                        "Literal prefix of pattern '%s' does not exist or "
+                        "is not a directory; no matches.",
+                        pattern);
+                    SeqDestroy(data.components);
+                    continue;
+                }
+
                 PathWalk(
-                    FILE_SEPARATOR_STR,
+                    start_dir,
                     PathWalkCallback,
                     &data,
                     GlobFindDataCopy,
                     GlobFindDataDestroy);
+                free(start_dir);
             }
         }
         else
         {
+            /* Relative path like "foo/bar/glob". Same literal-prefix peel
+             * as for absolute paths -- start PathWalk() at the deepest
+             * literal directory instead of always at '.'. Pass NULL as the
+             * seed so the peel builds a bare relative path (e.g. "foo/bar")
+             * rather than "./foo/bar"; PathWalk() formats its matches
+             * differently when started at "." versus a named directory. */
+            char *const start_dir = PeelLiteralPrefix(NULL, data.components);
+            if (start_dir == NULL)
+            {
+                Log(LOG_LEVEL_DEBUG,
+                    "Literal prefix of pattern '%s' does not exist or is "
+                    "not a directory; no matches.",
+                    pattern);
+                SeqDestroy(data.components);
+                continue;
+            }
+
             PathWalk(
-                ".",
+                start_dir,
                 PathWalkCallback,
                 &data,
                 GlobFindDataCopy,
                 GlobFindDataDestroy);
+            free(start_dir);
         }
 
         SeqDestroy(data.components);

--- a/libutils/glob_lib.h.in
+++ b/libutils/glob_lib.h.in
@@ -76,6 +76,18 @@ Seq *GlobFind(const char *pattern);
  */
 bool GlobMatch(const char *pattern, const char *filename);
 
+/**
+ * @brief Return true if @p str is a wildcard pattern -- i.e. it contains a
+ *        glob metacharacter ('*', '?', '[', ']') or a brace-expansion
+ *        character ('{', '}').
+ *
+ * The inverse (a non-pattern) is a literal path component, which can be
+ * resolved with a single stat(2) instead of an opendir(3) + getdents(2) +
+ * stat-each-entry walk. Brace characters count because GlobMatch() performs
+ * brace expansion (see ExpandBraces()). See ENT-14146.
+ */
+bool IsWildcardPattern(const char *str);
+
 #endif // WITH_PCRE2
 
 /**

--- a/tests/unit/glob_lib_test.c
+++ b/tests/unit/glob_lib_test.c
@@ -274,6 +274,82 @@ static void test_glob_find(void)
         assert_string_equal(SeqAt(matches, 0), "." FILE_SEPARATOR_STR);
         SeqDestroy(matches);
     }
+    /* Relative pattern with a multi-component literal prefix. Exercises the
+     * PeelLiteralPrefix() path that starts PathWalk() under a deeper
+     * subdirectory than '.', avoiding enumeration of unrelated siblings.
+     * See ENT-14146. */
+    {
+        char template[] = "test_glob_find_rel_XXXXXX";
+        const char *const test_dir = mkdtemp(template);
+        assert_true(test_dir != NULL);
+
+        char path[PATH_MAX];
+        int ret = snprintf(
+            path,
+            PATH_MAX,
+            "%s" FILE_SEPARATOR_STR "alpha" FILE_SEPARATOR_STR "beta"
+                FILE_SEPARATOR_STR "gamma",
+            test_dir);
+        assert_true(ret < PATH_MAX && ret >= 0);
+        for (size_t depth = 1; depth <= 3; depth++)
+        {
+            char partial[PATH_MAX];
+            const char *const parts[3] = {"alpha", "beta", "gamma"};
+            int n = snprintf(partial, PATH_MAX, "%s", test_dir);
+            for (size_t k = 0; k < depth; k++)
+            {
+                n += snprintf(partial + n, PATH_MAX - n,
+                              FILE_SEPARATOR_STR "%s", parts[k]);
+                assert_true(n < PATH_MAX && n >= 0);
+            }
+            assert_int_equal(mkdir(partial, (mode_t) 0700), 0);
+        }
+
+        char file1[PATH_MAX], file2[PATH_MAX], sibling[PATH_MAX];
+        ret = snprintf(file1, PATH_MAX, "%s" FILE_SEPARATOR_STR "one.txt", path);
+        assert_true(ret < PATH_MAX && ret >= 0);
+        ret = snprintf(file2, PATH_MAX, "%s" FILE_SEPARATOR_STR "two.txt", path);
+        assert_true(ret < PATH_MAX && ret >= 0);
+        ret = snprintf(sibling, PATH_MAX,
+                       "%s" FILE_SEPARATOR_STR "alpha" FILE_SEPARATOR_STR
+                       "should-not-be-matched.txt", test_dir);
+        assert_true(ret < PATH_MAX && ret >= 0);
+        FILE *fp;
+        assert_true((fp = fopen(file1, "w")) != NULL);
+        fclose(fp);
+        assert_true((fp = fopen(file2, "w")) != NULL);
+        fclose(fp);
+        assert_true((fp = fopen(sibling, "w")) != NULL);
+        fclose(fp);
+
+        char rel[PATH_MAX];
+        ret = snprintf(rel, PATH_MAX,
+                       "%s" FILE_SEPARATOR_STR "alpha" FILE_SEPARATOR_STR
+                       "beta" FILE_SEPARATOR_STR "gamma" FILE_SEPARATOR_STR
+                       "*.txt", test_dir);
+        assert_true(ret < PATH_MAX && ret >= 0);
+
+        Seq *const matches = GlobFind(rel);
+        assert_int_equal(SeqLength(matches), 2);
+        SeqDestroy(matches);
+
+        unlink(file1);
+        unlink(file2);
+        unlink(sibling);
+        char pdir[PATH_MAX];
+        ret = snprintf(pdir, PATH_MAX, "%s" FILE_SEPARATOR_STR "alpha"
+                       FILE_SEPARATOR_STR "beta" FILE_SEPARATOR_STR "gamma",
+                       test_dir);
+        rmdir(pdir);
+        ret = snprintf(pdir, PATH_MAX, "%s" FILE_SEPARATOR_STR "alpha"
+                       FILE_SEPARATOR_STR "beta", test_dir);
+        rmdir(pdir);
+        ret = snprintf(pdir, PATH_MAX, "%s" FILE_SEPARATOR_STR "alpha",
+                       test_dir);
+        rmdir(pdir);
+        rmdir(test_dir);
+        (void) ret;
+    }
 }
 
 #endif // WITH_PCRE2
@@ -762,6 +838,38 @@ static void test_glob_file_list(void)
     StringSetDestroy(matches);
 }
 
+#ifdef WITH_PCRE2
+static void test_is_wildcard_pattern(void)
+{
+    /* Literal components -- empty string and ordinary names are NOT patterns. */
+    assert_false(IsWildcardPattern(""));
+    assert_false(IsWildcardPattern("var"));
+    assert_false(IsWildcardPattern("CFEngine-3.24.1-Install.log"));
+    assert_false(IsWildcardPattern("path/with/slashes"));
+    assert_false(IsWildcardPattern("dots.and-dashes_ok"));
+
+    /* Any of '*', '?', '[', ']' anywhere makes it a wildcard pattern. */
+    assert_true(IsWildcardPattern("*"));
+    assert_true(IsWildcardPattern("a*"));
+    assert_true(IsWildcardPattern("*a"));
+    assert_true(IsWildcardPattern("file?.txt"));
+    assert_true(IsWildcardPattern("[abc].cf"));
+    assert_true(IsWildcardPattern("CFEngine*Install.log"));
+
+    /* Brace expansion is performed by GlobMatch()/ExpandBraces(), so a brace
+     * component is a pattern too -- otherwise a directory like "{lib,log}"
+     * would be peeled as a literal prefix and match nothing (ENT-14146). */
+    assert_true(IsWildcardPattern("utils.{c,h}"));
+    assert_true(IsWildcardPattern("{lib,log}"));
+
+    /* Conservative case: a lone ']' with no matching '[' is not truly a
+     * wildcard, but is reported as one. This only forfeits the literal-prefix
+     * optimization for the rare name containing ']'; match results are
+     * unchanged because the component falls back to PathWalk()+GlobMatch(). */
+    assert_true(IsWildcardPattern("a]b"));
+}
+#endif // WITH_PCRE2
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -772,6 +880,7 @@ int main()
         unit_test(test_translate_bracket),
         unit_test(test_translate_glob),
         unit_test(test_glob_match),
+        unit_test(test_is_wildcard_pattern),
         unit_test(test_glob_find),
 #endif // WITH_PCRE2
         unit_test(test_glob_file_list),


### PR DESCRIPTION
`GlobFind()` handed every absolute pattern to `PathWalk("/", ...)`, which enumerated and `stat`'d every entry of each parent directory on the way down — even when the path components were literal with no glob metacharacters. Relative patterns did the same thing rooted at `.`.

For a pattern like `/var/cfengine/state/diff/*.diff`, you'd get `opendir("/") + getdents + stat` on every top-level entry of `/` before the walk ever reached `/var`. When one of those top-level entries is a stale NFS mount, `newfstatat` blocks indefinitely in `rpc_wait_bit_killable` and the whole process wedges in uninterruptible `D` state. `cf-execd` then spawns a new `cf-promises` every cycle, each of which also wedges — the pile-up the customer reported on [ENT-14146](https://tracker.mender.io/browse/ENT-14146).

To fix:

Peel literal components (no `*`, `?`, `[`, `]`) off the front of the component sequence and start `PathWalk()` at the deepest literal directory. For `/var/cfengine/state/diff/*.diff` the walk becomes:

```
stat("/var") -> stat("/var/cfengine") -> stat("/var/cfengine/state") -> stat("/var/cfengine/state/diff")
opendir("/var/cfengine/state/diff") + getdents + match *.diff
```

It never touches `/dev`, `/proc`, or any unrelated top-level entry. Same logic now applies to relative patterns — `a/b/c/*.txt` opens only `./a/b/c`, never `./a/d` or `./a/sibling.txt`.

The peel lives in `GlobFind()` (not `PathWalk()`) because that's where the component sequence is known. `PathWalk()` stays general-purpose.

Not covered:

- Escaped glob metacharacters (`\*`, `\?`). `IsGlobLiteral` is conservative — sees the `*`, returns false, falls back to the existing `PathWalk + GlobMatch` flow which does honor the escape.
- Windows network paths (`\\host\...`) and disk paths (`C:\...`) are unchanged.


Ticket: ENT-14146

[ENT-14146]: https://northerntech.atlassian.net/browse/ENT-14146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ