### PR TITLE
Adjusted ifdef to use __APPLE__ instead of DARWIN

### DIFF
--- a/libutils/unix_dir.c
+++ b/libutils/unix_dir.c
@@ -92,7 +92,7 @@ const struct dirent *DirRead(Dir *dir)
 {
     assert(dir != NULL);
     errno = 0;
-#if defined __linux__ || defined DARWIN
+#if defined (__linux__) || defined (__APPLE__)
     return readdir((DIR *) dir->dirh); // Sets errno for error
 #else // "exotics" use readdir_r
 


### PR DESCRIPTION
__APPLE__ is used more often and when this change was built in a core pull request workflow the DARWIN macro seemed to not be defined

Ticket: ENT-14208
