### PR TITLE
Older toolchains lack alloca so use __builtin_alloca which is more widely available if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,6 +473,7 @@ dnl ######################################################################
 AC_C_CONST
 
 AC_FUNC_FSEEKO
+AC_FUNC_ALLOCA
 AC_SYS_LARGEFILE
 AC_TYPE_OFF_T
 

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -306,6 +306,24 @@ void globfree(glob_t *pglob);
 # endif
 #endif
 
+// from https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/Particular-Functions.html
+#if HAVE_ALLOCA_H
+# include <alloca.h>
+#elif defined __GNUC__
+# define alloca __builtin_alloca
+#elif defined _AIX
+# define alloca __alloca
+#elif defined _MSC_VER
+# include <malloc.h>
+# define alloca _alloca
+#else
+# include <stddef.h>
+# ifdef  __cplusplus
+extern "C"
+# endif
+void *alloca (size_t);
+#endif
+
 #include <fcntl.h>
 
 #ifdef HAVE_VFS_H


### PR DESCRIPTION
This was affecting the Solaris platform using gcc 4.5.2

Ticket: ENT-14344
Changelog: none
